### PR TITLE
UK police data api links added [Again]

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,9 @@ A collective list of JSON APIs for use in web development.
 | API | Description | OAuth |Link |
 |---|---|---|---|
 | Full Contact | Get Social Media profiles and contact Information | Yes | [Go!](https://www.fullcontact.com/developer/docs/) |
+
+### Security
+
+| API | Description | OAuth |Link |
+|---|---|---|---|
+| UK Police | UK Police data | No | [Go!](https://data.police.uk/docs/) |


### PR DESCRIPTION
This is the site for open data about crime and policing in England, Wales and Northern Ireland.

You can download street-level crime, outcome, and stop and search data in clear and simple CSV format and explore the API containing detailed crime data and information about individual police forces and neighbourhood teams.

You can also download data on police activity, and a range of data collected under the police annual data requirement (ADR) including arrests and 101 call handling.

All the data on this site is made available under the Open Government Licence.