### PR TITLE
Corrected AniList OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collective list of JSON APIs for use in web development.
 | API | Description | OAuth |Link |
 |---|---|---|---|
 | Hummingbird | Hummingbird Anime API | No | [Go!](https://hummingbird.me/) |
-| AniList | AniList Anime API | No | [Go!](http://anilist-api.readthedocs.org/en/latest/#) |
+| AniList | AniList Anime API | Yes | [Go!](http://anilist-api.readthedocs.org/en/latest/#) |
 
 ### Bike
 | API | Description | OAuth |Link |


### PR DESCRIPTION
The AniList API does implement OAuth based authentication, for some reason it wasn't mentioned any where in the documentation but thats [been amended now](http://anilist-api.readthedocs.org/en/latest/authentication.html).

Thanks