### PR TITLE
Add Nutritionix

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ A collective list of JSON APIs for use in web development.
 |---|---|---|---|
 | OpenCage | Forward and reverse geocoding using open data | No | [Go!](https://geocoder.opencagedata.com) |
 
+### Health
+
+| API | Description | OAuth |Link |
+|---|---|---|---|
+| Nutritionix | Worlds largest verified nutrition database | No, but `apiKey` query string | [Go!](https://developer.nutritionix.com/) |
+
 ### Media
 
 | API | Description | OAuth |Link |


### PR DESCRIPTION
Added in Nutritionix. Not sure exactly what the category for this should be. I left it as **Health** for now but was also thinking about just using **Food**. 

Either way Nutritionix is an API I used recently for searching for nutrition facts about all kinds of food and it was pretty good. Think its a good addition to the list.