### PR TITLE
Correct Transport for London acronym

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ A collective list of JSON APIs for use in web development.
 ### Transportation
 | API | Description | OAuth |Link |
 |---|---|---|---|
-| Transport for London | TFL API | No | [Go!](https://api.tfl.gov.uk) |
+| Transport for London | TfL API | No | [Go!](https://api.tfl.gov.uk) |
 | Transport for Belgium | Belgian transport API | No | [Go!](https://hello.irail.be/api/) |
 | Transport for Germany | Deutsche Bahn (DB) API | No | [Go!](http://data.deutschebahn.com/apis/fahrplan/) |
 | Transport for Switzerland | Swiss public transport API | No | [Go!](https://transport.opendata.ch/) |


### PR DESCRIPTION
The correct acronym for Transport for London is "TfL" with a lowercase "f".