### PR TITLE
Added 18F USA Government

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A collective list of JSON APIs for use in web development.
 
 | API | Description | OAuth |Link |
 |---|---|---|---|
+| 18F | US Federal Government /Developer Program | No | [Go!](http://18f.github.io/API-All-the-X/) |
 | Abbreviation API | Get abbreviations and meanings | No |[Go!](https://market.mashape.com/daxeel/abbreviations) |
 | Callook.info API | United States ham radio callsigns | No |[Go!](https://callook.info) |
 | Celebinfo API | Celebrity information API | No |[Go!](https://market.mashape.com/daxeel/celebinfo/) |


### PR DESCRIPTION
18F is the federal government group that is trying to help add APIs to all US government agencies. This effort is named /Development because they want each agency to add a /development page fright off their homepage. Specifically they have a master list of 282 Agencies, and which ones have an API as one of the assets within their repo:
https://github.com/18F/API-All-the-X/blob/gh-pages/_data/agency_progress.csv