### PR TITLE
Fix typo in Yelp API description

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A collective list of JSON APIs for use in web development.
 | Callook.info API | United States ham radio callsigns | No |[Go!](https://callook.info) |
 | Celebinfo API | Celebrity information API | No |[Go!](https://market.mashape.com/daxeel/celebinfo/) |
 | Open Government | United State Government Open Data | No |[Go!](https://www.data.gov/) |
-| Yelp | Find Local Bussiness | Yes |[Go!](https://www.yelp.com/developers) |
+| Yelp | Find Local Business | Yes |[Go!](https://www.yelp.com/developers) |
 | Quandl API | Stock Market Data | No |[Go!](https://www.quandl.com/) |
 
 ### Exchange


### PR DESCRIPTION
Minor change. Yelp API description had a typo: "bussiness". Simply fixed this to "business".