### PR TITLE
Corrections on auth for Spotify and Deutsche Bahn; added tumblr API

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ A collective list of JSON APIs for use in web development.
 | Mixcloud | Music | No | [Go!](https://www.mixcloud.com/developers/) |
 | MusicBrainz | Music | No | [Go!](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2) |
 | Soundcloud | Music | No | [Go!](https://developers.soundcloud.com/) |
-| Spotify | Music | No | [Go!](https://developer.spotify.com/web-api/migration-guide/) |
+| Spotify | Music | Parts | [Go!](https://developer.spotify.com/web-api/migration-guide/) |
 | Musixmatch | Music | No, but `apikey` query string | [Go!](https://developer.musixmatch.com/) |
 
 ### Open Source projects

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ A collective list of JSON APIs for use in web development.
 |---|---|---|---|
 | Transport for London | TFL API | No | [Go!](https://api.tfl.gov.uk) |
 | Transport for Belgium | Belgian transport API | No | [Go!](https://hello.irail.be/api/) |
-| Transport for Germany | Deutsche Bahn (DB) API | No | [Go!](http://data.deutschebahn.com/apis/fahrplan/) |
+| Transport for Germany | Deutsche Bahn (DB) API | No, but `authKey` query string | [Go!](http://data.deutschebahn.com/apis/fahrplan/) |
 | Transport for Switzerland | Swiss public transport API | No | [Go!](https://transport.opendata.ch/) |
 | Transport for Budapest | Budapest public transport API | No | [Go!](http://docs.bkkfutar.apiary.io/) |
 | Transport for Norway | Norwegian transport API | No | [Go!](http://reisapi.ruter.no/help) |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A collective list of JSON APIs for use in web development.
 | Facebook API | Facebook Login, Share on FB, Social Plugins, Analytics and more | Yes | [Go!](https://developers.facebook.com/) |
 | Twitter API | Read and write Twitter data | Yes | [Go!](https://dev.twitter.com/rest/public) |
 | Telegram API | Read and write Telegram data | Yes | [Go!](https://core.telegram.org/api#getting-started) |
+| Tumblr API | Posts, Likes, Info, ... on Tumblr blogs | Yes | [Go!](https://www.tumblr.com/docs/en/api/v2) |
 
 ### Sports/Fitness
 


### PR DESCRIPTION
## Deutsche Bahn
> Every client using the API needs to pass a valid authentication key in every request. This parameter
has to be appended to the URL: `authKey=<your_key_here>`. 

[Source](http://data.deutschebahn.com/apis/fahrplan/Fpl-API-Doku-Open-Data-BETA-0_81_2.pdf)

## Spotify
[https://developer.spotify.com/web-api/authorization-guide/](https://developer.spotify.com/web-api/authorization-guide/)
