### PR TITLE
Included Swedish Transport Consumer - TrafikLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ A collective list of JSON APIs for use in web development.
 | Transport for Paris, France | RATP Open Data API | No | [Go!](http://data.ratp.fr/api/v1/console/datasets/1.0/search/) |
 | Transport for Sao Paulo, Brazil | SPTrans | Yes | [Go!](http://www.sptrans.com.br/desenvolvedores/APIOlhoVivo/Documentacao.aspx) |
 | Transport for The Netherlands | NS | No | [Go!](http://www.ns.nl/reisinformatie/ns-api) |
+| Transport for Sweden | Public Transport consumer | Yes | [Go!](https://www.trafiklab.se/api) |
 | Schiphol Airport API | Schiphol | Yes | [Go!](https://flight-info.3scale.net/)
 
 ### Vehicle


### PR DESCRIPTION
Added Trafiklab, a free to use Public Transport Consumer API in Sweden:


"Trafiklab is a community for open traffic. A place where you as a developer can share data and APIs  for public transport in Sweden and easily get the information you need to develop sharp services."