### PR TITLE
APIs.guru: Wikipedia for Web APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A collective list of JSON APIs for use in web development.
 | API | Description | OAuth | Link |
 |---|---|---|---|
 | Adorable Avatars | Generate random cartoon avatars | No | [Go!](http://avatars.adorable.io) |
+| APIs.guru | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | [Go!] (https://apis.guru/api-doc/) |
 | CDNJS | Library info on CDNJS | No | [Go!](https://api.cdnjs.com/libraries/jquery) |
 | Faceplusplus | A tool to detect face | Yes | [GO!](http://www.faceplusplus.com/uc_home/) |
 | Github - User Data | Pull public information for a user's github | No | [Go!](https://api.github.com/users/hackeryou) |


### PR DESCRIPTION
My catalog has [OpenAPI/Swagger](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) descriptions for 200+ APIs and 6000+ endpoints. People build interesting startup/projects on top of it:
https://github.com/APIs-guru/api-models#existing-integrations

P.S. It's really funny to add API for catalog of API descriptions into this API catalog :smile: 
![we-need-to-go-deeper_inception](https://cloud.githubusercontent.com/assets/8336157/14569514/e28fc270-0347-11e6-9fd2-d9f3fce4fc45.jpg)