### PR TITLE
Added OvApi.nl

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ A collective list of JSON APIs for use in web development.
 | Transport for Washington, US | Washington Metro transport API | Yes | [Go!](https://developer.wmata.com/) |
 | Transport for Paris, France | RATP Open Data API | No | [Go!](http://data.ratp.fr/api/v1/console/datasets/1.0/search/) |
 | Transport for Sao Paulo, Brazil | SPTrans | Yes | [Go!](http://www.sptrans.com.br/desenvolvedores/APIOlhoVivo/Documentacao.aspx) |
-| Transport for The Netherlands | NS | No | [Go!](http://www.ns.nl/reisinformatie/ns-api) |
+| Public Transport for The Netherlands | GTFS OvAPI  | No | [Go!](http://gtfs.ovapi.nl/) |
+| Trains for The Netherlands | Dutch Railways REST API | No | [Go!](http://www.ns.nl/reisinformatie/ns-api) |
 | Schiphol Airport API | Schiphol | Yes | [Go!](https://flight-info.3scale.net/)
 
 ### Vehicle


### PR DESCRIPTION
OvAPI is a collection of a lot of Dutch public transportation APIs in the GTFS format. 