### PR TITLE
Add apiKey comment to Libraries.io entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ A collective list of JSON APIs for use in web development.
 
 | API | Description | OAuth |Link |
 |---|---|---|---|
-| BreweryDB | Beer | No, but apiKey query string |[Go!](http://www.brewerydb.com/developers) |
-| LCBO API | Alcohol | No, but apiKey query string |[Go!](https://lcboapi.com/) |
+| BreweryDB | Beer | No, but `apiKey` query string |[Go!](http://www.brewerydb.com/developers) |
+| LCBO API | Alcohol | No, but `apiKey` query string |[Go!](https://lcboapi.com/) |
 
 ### Data Access
 
@@ -126,7 +126,7 @@ A collective list of JSON APIs for use in web development.
 | API | Description | OAuth |Link |
 |---|---|---|---|
 | Drupal.org | Drupal.org API | No | [Go!](https://www.drupal.org/drupalorg/api) |
-| Libraries.io | Open source software libraries | No | [Go!](https://libraries.io/api) |
+| Libraries.io | Open source software libraries | No, but `apiKey` query string | [Go!](https://libraries.io/api) |
 
 ### Security
 


### PR DESCRIPTION
From the [website](https://libraries.io/api):

`All API requests must include api_key parameter, get your api key from your account page`