### PR TITLE
British National Bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A collective list of JSON APIs for use in web development.
 | API | Description | OAuth | Link |
 |---|---|---|---|
 | 500px |  Photography Community | Yes | [Go!](https://github.com/500px/api-documentation)
+| British National Bibliography | Books | No | [Go!](http://bnb.data.bl.uk/) |
 | Chuck Norris Database | Jokes | No | [Go!](http://www.icndb.com/api) |
 | Dribbble | Design | Yes | [Go!](http://developer.dribbble.com/v1/) |
 | File.io | Files | No | [Go!](https://file.io) |


### PR DESCRIPTION
> The BNB Linked Data Platform provides access to the British National Bibliography published as linked open data and made available through SPARQL services.  Two different interfaces are provided:  a SPARQL editor, and /sparql a service endpoint for remote queries. Alternatively, use the search box below to enter a plain text term.

Added via my blog post https://shkspr.mobi/blog/2016/05/easy-apis-without-authentication/