### PR TITLE
Fix link to Spotify's Web API

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ A collective list of JSON APIs for use in web development.
 | Musixmatch | Music | No, but `apikey` query string | [Go!](https://developer.musixmatch.com/) |
 | Songsterr | Provides guitar, bass and drums tabs and chords  | No | [Go!](https://www.songsterr.com/a/wa/api/) |
 | Soundcloud | Music | No | [Go!](https://developers.soundcloud.com/) |
-| Spotify | Music | Parts | [Go!](https://developer.spotify.com/web-api/migration-guide/) |
+| Spotify | Music | Parts | [Go!](https://developer.spotify.com/web-api/) |
 
 ### Open Source projects
 


### PR DESCRIPTION
Replaced link to Spotify's Web API with one that points to the Web API's landing page. (The old link pointed to a migration page from the old Web API.)