### PR TITLE
Adding the Nomad List API

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ A collective list of JSON APIs for use in web development.
 | Community Transit | Transitland API | No | [Go!](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints) |
 | Goibibo | API for travel search  | No, but `apiKey` query string | [Go!](https://developer.goibibo.com/docs) |
 | Indian Railways | Indian Railways API | No, but a token is required |[Go!](http://api.erail.in/) |
+| The Nomad List | A list of the best places to live/work remotely | No | [Go!](https://nomadlist.com/faq) |
 | Schiphol Airport API | Schiphol | Yes | [Go!](https://flight-info.3scale.net/) |
 | TransitLand | Transit Aggregation | No | [Go!](https://transit.land/documentation/datastore/api-endpoints.html)
 | Transport for Atlanta, US | Marta | No | [Go!](http://www.itsmarta.com/developers/data-sources/marta-bus-realtime-restful-api.aspx) |


### PR DESCRIPTION
The documentation isn't great, but the endpoint is very cool:

From https://nomadlist.com/faq:
"Nomad List finds you the best places in the world to live and work remotely.	It collects over 50,000 data points about 500+ cities around the world, from cost of living, temperature to safety. "