### PR TITLE
Filter Media into separate categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ A collective list of JSON APIs for use in web development.
 
 | API | Description | OAuth | Link |
 |---|---|---|---|
-| Forismatic |Inspirational Quotes  | No |[Go!](http://forismatic.com/en/api/) |
-| Medium | community of readers and writers offering unique perspectives on ideas. | Yes | [Go!](https://github.com/Medium/medium-api-docs)
+| Forismatic | Inspirational Quotes | No | [Go!](http://forismatic.com/en/api/) |
+| Medium | Community of readers and writers offering unique perspectives on ideas. | Yes | [Go!](https://github.com/Medium/medium-api-docs)
 | Traitify | Assess, collect, and analyze Personality | No | [Go!](https://developer.traitify.com/) |
 
 ### Science


### PR DESCRIPTION
The Media category was becoming too vague and too cluttered with items that fell into other, already existing, categories. By breaking up this category, we are able to allow viewers to quickly find what they need, instead of making them search the category they want and then have to double-check the "catch-all" basin that was Media. 

These changes should cover issue #127.