### PR TITLE
Move Planets section into Science

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,18 +234,13 @@ A collective list of JSON APIs for use in web development.
 | screenshotlayer API | URL 2 Image | No | [Go!](https://screenshotlayer.com) |
 | Unsplash | Photography | Yes | [Go!](https://unsplash.com/developers) |
 
-### Planets
-
-| API | Description | OAuth | Link |
-|---|---|---|---|
-| Minor Planet Center | Asterank.com API | No | [Go!](http://www.asterank.com/mpc) |
-
 ### Science
 
 | API | Description | OAuth | Link |
 |---|---|---|---|
 | Fedger.io | Query machine intelligence data | No | [Go!](https://dev.fedger.io/docs/) |
 | inspirehep.net | High Energy Physics info. system | No | [Go!](https://inspirehep.net/info/hep/api?ln=en) |
+| Minor Planet Center | Asterank.com API | No | [Go!](http://www.asterank.com/mpc) |
 | NASA | NASA data, including imagery | No | [Go!](https://api.nasa.gov) |
 | Open Notify | ISS astronauts, current location API | No | [Go!](http://open-notify.org/Open-Notify-API/) |
 | Sunrise and Sunset | Sunset and sunrise times for a given latitude and longitude. | No | [Go!](http://sunrise-sunset.org/api) |


### PR DESCRIPTION
Similar to the Media section, by moving the Planets section into Science, it creates a more concise way for users to search (i.e. no need to check Science, and then go back and look for another section to cover what they are looking for).
