### PR TITLE
Hummingbird is dead, Long live Kitsu

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For information on contributing to this project, please see the [contributing gu
 | API | Description | Auth | Link |
 |---|---|---|---|
 | AniList | AniList Anime API | `oAuth` | [Go!](http://anilist-api.readthedocs.org/en/latest/#) |
-| Kitsu | Kitsu Anime API | No | [Go!](http://docs.kitsu17.apiary.io/) |
+| Kitsu | Kitsu Anime API | `oAuth` | [Go!](http://docs.kitsu17.apiary.io/) |
 
 ### Anti-Malware
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For information on contributing to this project, please see the [contributing gu
 | API | Description | Auth | Link |
 |---|---|---|---|
 | AniList | AniList Anime API | `oAuth` | [Go!](http://anilist-api.readthedocs.org/en/latest/#) |
-| Hummingbird | Hummingbird Anime API | No | [Go!](https://hummingbird.me/) |
+| Kitsu | Kitsu Anime API | No | [Go!](http://docs.kitsu17.apiary.io/) |
 
 ### Anti-Malware
 


### PR DESCRIPTION
Removed Hummingbird and updated with the Kitsu api details.

Source: https://medium.com/heykitsu/hummingbird-is-dead-long-live-kitsu-bda6ccfbbcce#.xixj9r30c
https://forums.hummingbird.me/t/kitsu-api-documentation/33367