### PR TITLE
Add Category Note for Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,9 @@ Currently, the only accepted inputs for this field are as follows:
 * `X-Mashape-Key` - _the name of the header which may need to be sent_
 * `No` - _the API requires no authentication to run_
 
-Please continue to follow the alphabetical ordering that is in place per section.
+Please continue to follow the alphabetical ordering that is in place per section. 
+
+If an API seems to fall into multiple categories, please place the listing within the section most in line with the services offered through the API. For example, the Instagram API is lsted under `Social` since it is mainly a social network, even though it could also apply to `Photography`.
 
 ##Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Currently, the only accepted inputs for this field are as follows:
 
 Please continue to follow the alphabetical ordering that is in place per section. 
 
-If an API seems to fall into multiple categories, please place the listing within the section most in line with the services offered through the API. For example, the Instagram API is lsted under `Social` since it is mainly a social network, even though it could also apply to `Photography`.
+If an API seems to fall into multiple categories, please place the listing within the section most in line with the services offered through the API. For example, the Instagram API is listed under `Social` since it is mainly a social network, even though it could also apply to `Photography`.
 
 ##Pull Request
 


### PR DESCRIPTION
A recent PR brought up the issue of API's that can span multiple sections. In order to try to keep this list from exploding with duplicate listings of the same services, I added a note to the contribution guide reminding contributors to place new listings under the category most appropriate to the service.