### PR TITLE
Create Math Section and Add Newton API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For information on contributing to this project, please see the [contributing gu
 * [Geocoding](#geocoding)
 * [Health](#health)
 * [Machine Learning](#machine-learning)
+* [Math](#math)
 * [Music](#music)
 * [News](#news)
 * [Open Source projects](#open-source-projects)
@@ -256,6 +257,12 @@ For information on contributing to this project, please see the [contributing gu
 |---|---|---|---|---|
 | Clarifai | Computer Vision | `oAuth` | Yes | [Go!](https://predictbgl.com/api) |
 | Wit.ai | Natural Language Processing | `oAuth` | Yes | [Go!](https://wit.ai/) |
+
+### Math
+
+| API | Description | Auth | HTTPS | Link |
+|---|---|---|---|---|
+| Newton | Symbolic and Arithmetic Math Calculator | No | Yes | [Go!](https://newton.now.sh/) |
 
 ### Music
 


### PR DESCRIPTION
In this Pull Request, I intend to add a mathematics section to this API list. This is because the API that I am adding is not accurately described as a Science API (but more of a Math API).