### PR TITLE
OAuth corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Example entry:
 
 Currently, the only accepted inputs for this field are as follows:
 
-* `oAuth` - _the API supports oAuth_
+* `OAuth` - _the API supports OAuth_
 * `apiKey` - _the API uses a private key string/token for authentication - try and use the correct parameter_
 * `X-Mashape-Key` - _the name of the header which may need to be sent_
 * `No` - _the API requires no authentication to run_

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ For information on contributing to this project, please see the [contributing gu
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| AniList | AniList Anime | `oAuth` | No | [Go!](http://anilist-api.readthedocs.org/en/latest/#) |
-| Kitsu | Kitsu Anime | `oAuth` | No | [Go!](http://docs.kitsu17.apiary.io/) |
+| AniList | AniList Anime | `OAuth` | No | [Go!](http://anilist-api.readthedocs.org/en/latest/#) |
+| Kitsu | Kitsu Anime | `OAuth` | No | [Go!](http://docs.kitsu17.apiary.io/) |
 
 ### Anti-Malware
 
@@ -71,8 +71,8 @@ For information on contributing to this project, please see the [contributing gu
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| Dribbble | Design | `oAuth` | No | [Go!](http://developer.dribbble.com/v1/) |
-| Noun Project | Icons | `oAuth` | No | [Go!](http://api.thenounproject.com/index.html) |
+| Dribbble | Design | `OAuth` | No | [Go!](http://developer.dribbble.com/v1/) |
+| Noun Project | Icons | `OAuth` | No | [Go!](http://api.thenounproject.com/index.html) |
 | Rijksmuseum| Art | No | Yes | [Go!](https://www.rijksmuseum.nl/en/api) |
 
 ### Books
@@ -81,7 +81,7 @@ For information on contributing to this project, please see the [contributing gu
 |---|---|---|---|---|
 | British National Bibliography | Books | No | No | [Go!](http://bnb.data.bl.uk/) |
 | Good Reads | Books | No | Yes | [Go!](https://www.goodreads.com/api) |
-| Google Books | Books | `oAuth` | Yes | [Go!](https://developers.google.com/books/) |
+| Google Books | Books | `OAuth` | Yes | [Go!](https://developers.google.com/books/) |
 
 ### Business
 
@@ -103,10 +103,10 @@ For information on contributing to this project, please see the [contributing gu
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| Box | File Sharing and Storage | `oAuth` | Yes | [Go!](https://developer.box.com/) |
-| Dropbox | File Sharing and Storage | `oAuth` | Yes | [Go!](https://www.dropbox.com/developers) |
-| Google Drive | File Sharing and Storage | `oAuth` | Yes | [Go!](https://developers.google.com/drive/) |
-| OneDrive | File Sharing and Storage | `oAuth` | Yes | [Go!](https://dev.onedrive.com/) |
+| Box | File Sharing and Storage | `OAuth` | Yes | [Go!](https://developer.box.com/) |
+| Dropbox | File Sharing and Storage | `OAuth` | Yes | [Go!](https://www.dropbox.com/developers) |
+| Google Drive | File Sharing and Storage | `OAuth` | Yes | [Go!](https://developers.google.com/drive/) |
+| OneDrive | File Sharing and Storage | `OAuth` | Yes | [Go!](https://dev.onedrive.com/) |
 
 ### Currency Exchange
 
@@ -122,12 +122,12 @@ For information on contributing to this project, please see the [contributing gu
 | Adorable Avatars | Generate random cartoon avatars | No | Yes | [Go!](http://avatars.adorable.io) |
 | APIs.guru | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | [Go!](https://apis.guru/api-doc/) |
 | CDNJS | Library info on CDNJS | No | Yes | [Go!](https://api.cdnjs.com/libraries/jquery) |
-| Faceplusplus | A tool to detect face | `oAuth` | No | [Go!](http://www.faceplusplus.com/uc_home/) |
+| Faceplusplus | A tool to detect face | `OAuth` | No | [Go!](http://www.faceplusplus.com/uc_home/) |
 | Github - User Data | Pull public information for a user's github | No | Yes | [Go!](https://api.github.com/users/hackeryou) |
-| Gitter | Chat for GitHub | `oAuth` | Yes | [Go!](https://developer.gitter.im/docs/) |
+| Gitter | Chat for GitHub | `OAuth` | Yes | [Go!](https://developer.gitter.im/docs/) |
 | Hipster Ipsum | Generates Hipster Ipsum text | No | No | [Go!](http://hipsterjesus.com/) |
 | JSONPlaceholder | Fake data for testing and prototyping | No | No | [Go!](http://jsonplaceholder.typicode.com/) |
-| LiveCoding | Live Coding Streaming | `oAuth` | Yes | [Go!](https://www.livecoding.tv/developer/applications/) |
+| LiveCoding | Live Coding Streaming | `OAuth` | Yes | [Go!](https://www.livecoding.tv/developer/applications/) |
 | Lorem Text | Generates Lorem Ipsum text | `X-Mashape-Key` as header | Yes | [Go!](https://market.mashape.com/montanaflynn/lorem-text-generator) |
 | Loripsum | The "lorem ipsum" generator that doesn't suck | No | No | [Go!](http://loripsum.net/) |
 | Myjson | A simple JSON store for your web or mobile app | No | No | [Go!](http://myjson.com/api) |
@@ -136,7 +136,7 @@ For information on contributing to this project, please see the [contributing gu
 | RandomUser | Generates random user data | No | Yes | [Go!](https://randomuser.me) |
 | ReqRes | A hosted REST-API ready to respond to your AJAX requests | No | No | [Go!](http://reqres.in/) |
 | RoboHash | Generate random robot/alien avatars | No | Yes | [Go!](https://robohash.org/) |
-| StackExchange | Q&A forum for developers | `oAuth` | Yes | [Go!](https://api.stackexchange.com/) |
+| StackExchange | Q&A forum for developers | `OAuth` | Yes | [Go!](https://api.stackexchange.com/) |
 | Stormpath | User Authentication | `apiKey` | Yes | [Go!](https://stormpath.com/) |
 | UI Faces | Find and generate sample avatars for user interfaces | No | No | [Go!](http://uifaces.com/api) |
 | UI Names | Generate random fake names | No | Yes | [Go!](https://github.com/thm/uinames) |
@@ -147,7 +147,7 @@ For information on contributing to this project, please see the [contributing gu
 |---|---|---|---|---|
 | File.io | Files | No | Yes | [Go!](https://file.io) |
 | pdflayer API | HTML/URL to PDF | No | Yes | [Go!](https://pdflayer.com) |
-| Wunderlist | Todo Lists | `oAuth` | Yes | [Go!](https://developer.wunderlist.com/documentation) |
+| Wunderlist | Todo Lists | `OAuth` | Yes | [Go!](https://developer.wunderlist.com/documentation) |
 
 ### Data Access
 
@@ -172,7 +172,7 @@ For information on contributing to this project, please see the [contributing gu
 | Scoop.it | Content Curation Service | `apiKey` query string | Yes | [Go!](https://www.scoop.it/dev) |
 | Wikipedia | Mediawiki Encyclopedia | No | Yes | [Go!](https://www.mediawiki.org/wiki/API:Main_page) |
 | Wordnik | Dictionary Data | No | No | [Go!](http://developer.wordnik.com) |
-| Yelp | Find Local Business | `oAuth` | Yes | [Go!](https://www.yelp.com/developers) |
+| Yelp | Find Local Business | `OAuth` | Yes | [Go!](https://www.yelp.com/developers) |
 
 ### Data Validation
 
@@ -212,7 +212,7 @@ For information on contributing to this project, please see the [contributing gu
 | Clash Royale | Clash Royale Game Information | No | Yes | [Go!](https://github.com/martincarrera/clash-royale-api)  |
 | Comic Vine | Comics | No | No | [Go!](http://comicvine.gamespot.com/api/documentation) |
 | Deck of Cards | Deck of Cards | No | No | [Go!](http://deckofcardsapi.com/)  |
-| Eve Online | Third-Party Developer Documentation | `oAuth` required for some parts | Yes | [Go!](https://eveonline-third-party-documentation.readthedocs.io/en/latest/) |
+| Eve Online | Third-Party Developer Documentation | `OAuth` required for some parts | Yes | [Go!](https://eveonline-third-party-documentation.readthedocs.io/en/latest/) |
 | Giant Bomb | Video Games | No | No | [Go!](http://www.giantbomb.com/api/documentation) |
 | Guild Wars 2 | Guild Wars 2 Game Information | `apiKey` query string (for some routes) | Yes | [Go!](https://wiki.guildwars2.com/wiki/API:Main) |
 | Magic The Gathering | Magic The Gathering Game Information | No | No | [Go!](http://magicthegathering.io/) |
@@ -221,7 +221,7 @@ For information on contributing to this project, please see the [contributing gu
 | Open Trivia | Trivia Questions | No | Yes | [Go!](https://opentdb.com/api_config.php) |
 | Pokéapi | Pokémon Information | No | No | [Go!](http://pokeapi.co) |
 | Riot Games | League of Legends Game Information | `apiKey` | Yes | [Go!](https://developer.riotgames.com/) |
-| Steam | Steam Client Interaction | `oAuth` | Yes | [Go!](https://developer.valvesoftware.com/wiki/Steam_Web_API) |
+| Steam | Steam Client Interaction | `OAuth` | Yes | [Go!](https://developer.valvesoftware.com/wiki/Steam_Web_API) |
 | SWAPI | Star Wars Information | No | Yes | [Go!](https://swapi.co) |
 
 ### Geocoding
@@ -238,7 +238,7 @@ For information on contributing to this project, please see the [contributing gu
 | Mapzen Search | Open Source & Open Data Global Geocoding Service | No | Yes | [Go!](https://mapzen.com/projects/search) |
 | Mexico | Mexico RESTful zip codes API | No | Yes | [Go!](https://github.com/IcaliaLabs/sepomex) |
 | OpenCage | Forward and reverse geocoding using open data | No | Yes | [Go!](https://geocoder.opencagedata.com) |
-| OpenStreetMap | Navigation, geolocation and geographical data | `oAuth` | No | [Go!](http://wiki.openstreetmap.org/wiki/API) |
+| OpenStreetMap | Navigation, geolocation and geographical data | `OAuth` | No | [Go!](http://wiki.openstreetmap.org/wiki/API) |
 | PostcodeData.nl | Provide geolocation data based on postcode for Dutch addresses | No | No | [Go!](http://api.postcodedata.nl/v1/postcode/?postcode=1211EP&streetnumber=60&ref=domeinnaam.nl&type=json) |
 | Postcodes.io | Postcode lookup & Geolocation for the UK | No | Yes | [Go!](https://postcodes.io) |
 
@@ -256,8 +256,8 @@ For information on contributing to this project, please see the [contributing gu
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| Clarifai | Computer Vision | `oAuth` | Yes | [Go!](https://predictbgl.com/api) |
-| Wit.ai | Natural Language Processing | `oAuth` | Yes | [Go!](https://wit.ai/) |
+| Clarifai | Computer Vision | `OAuth` | Yes | [Go!](https://predictbgl.com/api) |
+| Wit.ai | Natural Language Processing | `OAuth` | Yes | [Go!](https://wit.ai/) |
 
 ### Math
 
@@ -269,11 +269,11 @@ For information on contributing to this project, please see the [contributing gu
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| Deezer | Music | `oAuth` | No | [Go!](http://developers.deezer.com/api) |
-| Discogs | Music | `oAuth` | Yes | [Go!](https://www.discogs.com/developers/) |
+| Deezer | Music | `OAuth` | No | [Go!](http://developers.deezer.com/api) |
+| Discogs | Music | `OAuth` | Yes | [Go!](https://www.discogs.com/developers/) |
 | EchoNest | Music | No | No | [Go!](http://developer.echonest.com/docs/v4) |
-| Genius | Crowdsourced lyrics and music knowledge | `oAuth` | Yes | [Go!](https://docs.genius.com/) |
-| Jamendo | Music | `oAuth` | Yes | [Go!](https://developer.jamendo.com/v3.0) |
+| Genius | Crowdsourced lyrics and music knowledge | `OAuth` | Yes | [Go!](https://docs.genius.com/) |
+| Jamendo | Music | `OAuth` | Yes | [Go!](https://developer.jamendo.com/v3.0) |
 | iTunes Search | Software products | No | Yes | [Go!](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/) |
 | LastFm | Music | No | No | [Go!](http://www.last.fm/api) |
 | Mixcloud | Music | No | Yes | [Go!](https://www.mixcloud.com/developers/) |
@@ -282,7 +282,7 @@ For information on contributing to this project, please see the [contributing gu
 | Musixmatch | Music | `apikey` query string | Yes | [Go!](https://developer.musixmatch.com/) |
 | Songsterr | Provides guitar, bass and drums tabs and chords  | No | Yes | [Go!](https://www.songsterr.com/a/wa/api/) |
 | Soundcloud | Music | No | Yes | [Go!](https://developers.soundcloud.com/) |
-| Spotify | Music | `oAuth` required for some parts | Yes | [Go!](https://developer.spotify.com/web-api/) |
+| Spotify | Music | `OAuth` required for some parts | Yes | [Go!](https://developer.spotify.com/web-api/) |
 | Vagalume | Crowdsourced lyrics and music knowledge | `apikey` query string | Yes | [Go!](https://api.vagalume.com.br/docs/) |
 
 ### News
@@ -304,7 +304,7 @@ For information on contributing to this project, please see the [contributing gu
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
 | Forismatic | Inspirational Quotes | No | No | [Go!](http://forismatic.com/en/api/) |
-| Medium | Community of readers and writers offering unique perspectives on ideas. | `oAuth` | Yes | [Go!](https://github.com/Medium/medium-api-docs) |
+| Medium | Community of readers and writers offering unique perspectives on ideas. | `OAuth` | Yes | [Go!](https://github.com/Medium/medium-api-docs) |
 | Quotes on Design | Inspirational Quotes | No | Yes | [Go!](https://quotesondesign.com/api-v4-0/) |
 | Traitify | Assess, collect, and analyze Personality | No | Yes | [Go!](https://developer.traitify.com/) |
 
@@ -312,13 +312,13 @@ For information on contributing to this project, please see the [contributing gu
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| 500px |  Photography Community | `oAuth` | Yes | [Go!](https://github.com/500px/api-documentation) |
-| Flickr | Flickr Services | `oAuth` | Yes | [Go!](https://www.flickr.com/services/api/) |
-| Gfycat | Jiffier GIFs | `oAuth` | Yes | [Go!](https://developers.gfycat.com/api/) |
+| 500px |  Photography Community | `OAuth` | Yes | [Go!](https://github.com/500px/api-documentation) |
+| Flickr | Flickr Services | `OAuth` | Yes | [Go!](https://www.flickr.com/services/api/) |
+| Gfycat | Jiffier GIFs | `OAuth` | Yes | [Go!](https://developers.gfycat.com/api/) |
 | Giphy | Get all your gifs | No | Yes | [Go!](https://github.com/Giphy/GiphyAPI) |
-| Imgur | Images | `oAuth` | Yes | [Go!](https://api.imgur.com/#overview) |
+| Imgur | Images | `OAuth` | Yes | [Go!](https://api.imgur.com/#overview) |
 | ScreenShotLayer | URL 2 Image | No | Yes | [Go!](https://screenshotlayer.com) |
-| Unsplash | Photography | `oAuth` | Yes | [Go!](https://unsplash.com/developers) |
+| Unsplash | Photography | `OAuth` | Yes | [Go!](https://unsplash.com/developers) |
 
 ### Science
 
@@ -345,30 +345,30 @@ For information on contributing to this project, please see the [contributing gu
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| eBay | Sell and Buy on eBay | `oAuth` | Yes | [Go!](https://go.developer.ebay.com/) |
+| eBay | Sell and Buy on eBay | `OAuth` | Yes | [Go!](https://go.developer.ebay.com/) |
 
 ### Social
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| Discord bot | Make bots for Discord | `oAuth` | Yes | [Go!](https://discordapp.com/developers/docs/intro) |
-| Facebook API | Facebook Login, Share on FB, Social Plugins, Analytics and more | `oAuth` | Yes | [Go!](https://developers.facebook.com/) |
-| Foursquare | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `oAuth` | Yes | [Go!](https://developer.foursquare.com/) |
+| Discord bot | Make bots for Discord | `OAuth` | Yes | [Go!](https://discordapp.com/developers/docs/intro) |
+| Facebook API | Facebook Login, Share on FB, Social Plugins, Analytics and more | `OAuth` | Yes | [Go!](https://developers.facebook.com/) |
+| Foursquare | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth` | Yes | [Go!](https://developer.foursquare.com/) |
 | Fuck Off as a Service | Asks someone to fuck off | No | Yes | [Go!](https://www.foaas.com) |
-| Full Contact | Get Social Media profiles and contact Information | `oAuth` | Yes | [Go!](https://www.fullcontact.com/developer/docs/) |
+| Full Contact | Get Social Media profiles and contact Information | `OAuth` | Yes | [Go!](https://www.fullcontact.com/developer/docs/) |
 | HackerNews | Social news for CS and entrepreneurship | No | Yes | [Go!](https://github.com/HackerNews/API) |
-| Instagram | Instagram Login, Share on Instagram, Social Plugins and more | `oAuth` | Yes | [Go!](https://www.instagram.com/developer/) |
-| LinkedIn | The foundation of all digital integrations with LinkedIn | `oAuth` | Yes | [Go!](https://developer.linkedin.com/docs/rest-api) |
-| Telegram MTProto | Read and write Telegram data | `oAuth` | Yes | [Go!](https://core.telegram.org/api#getting-started) |
-| Telegram bot | Simplified HTTP version of the MTProto API for bots | `oAuth` | Yes | [Go!](https://core.telegram.org/bots/api) |
-| Pinterest | The world's catalog of ideas | `oAuth` | Yes | [Go!](https://developers.pinterest.com/) |
-| PWRTelegram bot | Boosted version of the Telegram bot API | `oAuth` | Yes | [Go!](https://pwrtelegram.xyz) |
-| Reddit | Homepage of the internet | `oAuth` required for some parts | Yes | [Go!](https://www.reddit.com/dev/api) |
-| Slack | Team Instant Messaging | `oAuth` | Yes | [Go!](https://api.slack.com/) |
-| Tumblr | Read and write Tumblr Data | `oAuth` | Yes | [Go!](https://www.tumblr.com/docs/en/api/v2) |
-| Twitch | Game Streaming API | `oAuth` | Yes | [Go!](https://github.com/justintv/Twitch-API) |
-| Twitter | Read and write Twitter data | `oAuth` | Yes | [Go!](https://dev.twitter.com/rest/public) |
-| vk API | Read and write vk dat | `oAuth` | Yes | [Go!](https://vk.com/dev/sites) |
+| Instagram | Instagram Login, Share on Instagram, Social Plugins and more | `OAuth` | Yes | [Go!](https://www.instagram.com/developer/) |
+| LinkedIn | The foundation of all digital integrations with LinkedIn | `OAuth` | Yes | [Go!](https://developer.linkedin.com/docs/rest-api) |
+| Telegram MTProto | Read and write Telegram data | `OAuth` | Yes | [Go!](https://core.telegram.org/api#getting-started) |
+| Telegram bot | Simplified HTTP version of the MTProto API for bots | `OAuth` | Yes | [Go!](https://core.telegram.org/bots/api) |
+| Pinterest | The world's catalog of ideas | `OAuth` | Yes | [Go!](https://developers.pinterest.com/) |
+| PWRTelegram bot | Boosted version of the Telegram bot API | `OAuth` | Yes | [Go!](https://pwrtelegram.xyz) |
+| Reddit | Homepage of the internet | `OAuth` required for some parts | Yes | [Go!](https://www.reddit.com/dev/api) |
+| Slack | Team Instant Messaging | `OAuth` | Yes | [Go!](https://api.slack.com/) |
+| Tumblr | Read and write Tumblr Data | `OAuth` | Yes | [Go!](https://www.tumblr.com/docs/en/api/v2) |
+| Twitch | Game Streaming API | `OAuth` | Yes | [Go!](https://github.com/justintv/Twitch-API) |
+| Twitter | Read and write Twitter data | `OAuth` | Yes | [Go!](https://dev.twitter.com/rest/public) |
+| vk API | Read and write vk dat | `OAuth` | Yes | [Go!](https://vk.com/dev/sites) |
 
 ### Sports/Fitness
 
@@ -376,13 +376,13 @@ For information on contributing to this project, please see the [contributing gu
 |---|---|---|---|---|
 | City Bikes | City Bikes around the world | No | No | [Go!](http://api.citybik.es/v2/) |
 | Ergast F1 | F1 data from the beginning of the world championships in 1950 | No | No | [Go!](http://ergast.com/mrd/) |
-| Fitbit | Fitbit Information | `oAuth` | Yes | [Go!](https://dev.fitbit.com/) |
+| Fitbit | Fitbit Information | `OAuth` | Yes | [Go!](https://dev.fitbit.com/) |
 | Football-Data.org | Football Data | No | No | [Go!](http://api.football-data.org) |
 | JCDecaux Bike | JCDecaux's self-service bicycles | `apiKey` query string | Yes | [Go!](https://developer.jcdecaux.com/) |
 | Cricket Live Scores | live-score | `X-Mashape-Key` as header | Yes | [Go!](https://market.mashape.com/dev132/cricket-live-scores) |
 | NFL Arrests | NFL Arrest Data | No | No | [Go!](http://nflarrest.com/api/) |
 | Pro Motocross | The RESTful AMA Pro Motocross lap times for every racer on the start gate | No | No | [Go!](http://promotocrossapi.com) |
-| Strava | Connect with athletes, activities and more | [`oAuth`](https://strava.github.io/api/v3/oauth/)| Yes | [Go!](https://strava.github.io/api/) |
+| Strava | Connect with athletes, activities and more | [`OAuth`](https://strava.github.io/api/v3/oauth/)| Yes | [Go!](https://strava.github.io/api/) |
 | Wger | Workout manager data as exercises, muscles or equipments | `apiKey` query string | Yes | [Go!](https://wger.de/en/software/api) |
 
 ### Transportation
@@ -394,7 +394,7 @@ For information on contributing to this project, please see the [contributing gu
 | Goibibo | API for travel search  | `apiKey` query string | Yes | [Go!](https://developer.goibibo.com/docs) |
 | Indian Railways | Indian Railways API | `token` | [Go!](http://api.erail.in/) |
 | The Nomad List | A list of the best places to live/work remotely | No | Yes | [Go!](https://nomadlist.com/faq) |
-| Schiphol Airport | Schiphol | `oAuth` | Yes | [Go!](https://flight-info.3scale.net/) |
+| Schiphol Airport | Schiphol | `OAuth` | Yes | [Go!](https://flight-info.3scale.net/) |
 | TransitLand | Transit Aggregation | No | Yes | [Go!](https://transit.land/documentation/datastore/api-endpoints.html) |
 | Transport for Atlanta, US | Marta | No | No | [Go!](http://www.itsmarta.com/developers/data-sources/marta-bus-realtime-restful-api.aspx) |
 | Transport for Belgium | Belgian transport API | No | Yes | [Go!](https://hello.irail.be/api/) |
@@ -407,25 +407,25 @@ For information on contributing to this project, please see the [contributing gu
 | Transport for Berlin | third-party VBB API | No | Yes | [Go!](https://github.com/derhuerst/vbb-rest/blob/master/docs/index.md) |
 | Transport for India | India Public Transport API | Api key | Yes | [Go!](https://data.gov.in/sector/transport) |
 | Transport for London, England | TfL API | No | Yes | [Go!](https://api.tfl.gov.uk) |
-| Transport for Minneapolis, US | NexTrip API | `oAuth` | No | [Go!](http://svc.metrotransit.org/) |
+| Transport for Minneapolis, US | NexTrip API | `OAuth` | No | [Go!](http://svc.metrotransit.org/) |
 | Transport for New York City | MTA | api key | No | [Go!](http://datamine.mta.info/) |
 | Transport for Norway | Norwegian transport API | No | No | [Go!](http://reisapi.ruter.no/help) |
 | Transport for Ottawa, Canada | OC Transpo next bus arrival API | No | No | [Go!](http://www.octranspo1.com/developers) |
 | Transport for Paris, France | RATP Open Data API | No | No | [Go!](http://data.ratp.fr/api/v1/console/datasets/1.0/search/) |
 | Transport for Philadelphia | SEPTA APIs | No | No | [Go!](http://www3.septa.org/hackathon/) |
 | Transport for Rio de Janeiro, Brazil | Prefeitura do Rio (City Hall) | No | No | [Go!](http://data.rio/group/transporte-e-mobilidade) |
-| Transport for Sweden | Public Transport consumer | `oAuth` | Yes | [Go!](https://www.trafiklab.se/api) |
+| Transport for Sweden | Public Transport consumer | `OAuth` | Yes | [Go!](https://www.trafiklab.se/api) |
 | Transport for Switzerland | Swiss public transport API | No | Yes | [Go!](https://transport.opendata.ch/) |
-| Transport for São Paulo, Brazil | SPTrans | `oAuth` | No | [Go!](http://www.sptrans.com.br/desenvolvedores/APIOlhoVivo/Documentacao.aspx) |
+| Transport for São Paulo, Brazil | SPTrans | `OAuth` | No | [Go!](http://www.sptrans.com.br/desenvolvedores/APIOlhoVivo/Documentacao.aspx) |
 | Transport for The Netherlands | NS | No | No | [Go!](http://www.ns.nl/reisinformatie/ns-api) |
 | Transport for Tokyo, Japan | Tokyo Metro | `apiKey` query string | Yes | [Go!](https://developer.tokyometroapp.jp/)  |
 | Transport for Toronto, Canada | TTC | No | Yes | [Go!](https://myttc.ca/developers) |
-| Transport for Vancouver, Canada | TransLink | `oAuth` | Yes | [Go!](https://developer.translink.ca/) |
-| Transport for Washington, US | Washington Metro transport API | `oAuth` | Yes | [Go!](https://developer.wmata.com/) |
+| Transport for Vancouver, Canada | TransLink | `OAuth` | Yes | [Go!](https://developer.translink.ca/) |
+| Transport for Washington, US | Washington Metro transport API | `OAuth` | Yes | [Go!](https://developer.wmata.com/) |
 | Transport for Madrid, Spain | Madrid BUS transport API | `apiKey` query string | No | [Go!](http://opendata.emtmadrid.es/Servicios-web/BUS) |
 | Transport for Auckland, New Zealand | Auckland Transport API  | No | Yes | [Go!](https://api.at.govt.nz/) |
-| Uber | Request Uber rides, reach riders, transport things, and reward drivers | `oAuth` | Yes | [Go!](https://developer.uber.com/) |
-| WhereIsMyTransport | Platform for public transport data in emerging cities  | `oAuth` | Yes | [Go!](https://developer.whereismytransport.com/) |
+| Uber | Request Uber rides, reach riders, transport things, and reward drivers | `OAuth` | Yes | [Go!](https://developer.uber.com/) |
+| WhereIsMyTransport | Platform for public transport data in emerging cities  | `OAuth` | Yes | [Go!](https://developer.whereismytransport.com/) |
 
 ### University
 
@@ -444,15 +444,15 @@ For information on contributing to this project, please see the [contributing gu
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
 | An API of Ice And Fire | Game Of Thrones API | No | Yes | [Go!](https://anapioficeandfire.com/) |
-| Dailymotion | Dailymotion Developer API | `oAuth` required for some parts | Yes | [Go!](https://developer.dailymotion.com/) |
+| Dailymotion | Dailymotion Developer API | `OAuth` required for some parts | Yes | [Go!](https://developer.dailymotion.com/) |
 | MovieDB | Movie Data | `apiKey` | Yes | [Go!](https://www.themoviedb.org/documentation/api) |
 | Netflix Roulette | Netflix database | No | No | [Go!](http://netflixroulette.net/api/) |
 | OMDB | Open movie database | No | Yes | [Go!](https://omdbapi.com/) |
 | Ron Swanson Quotes | Television | No | Yes | [Go!](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) |
 | TVMaze | TV Show Data | No | No | [Go!](http://www.tvmaze.com/api) |
 | Video download | Video download API for youtube, rai.it, mediaset.it, la7.it and hundreds of other sites. | No | Yes | [Go!](https://api.daniil.it) |
-| Vimeo | Vimeo Developer API | `oAuth` | Yes | [Go!](https://developer.vimeo.com/) |
-| YouTube | Add YouTube functionality to your sites and apps. | `oAuth` required for some parts | Yes | [Go!](https://developers.google.com/youtube/) |
+| Vimeo | Vimeo Developer API | `OAuth` | Yes | [Go!](https://developer.vimeo.com/) |
+| YouTube | Add YouTube functionality to your sites and apps. | `OAuth` required for some parts | Yes | [Go!](https://developers.google.com/youtube/) |
 
 ### Weather
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ For information on contributing to this project, please see the [contributing gu
 
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| 500px |  Photography Community | `oAuth` | Yes | [Go!](https://github.com/500px/api-documentation) |
+| 500px |  Photography Community | `oAuth` | Yes | [Go!](https://github.com/500px/api-documentation) |
 | Flickr | Flickr Services | `oAuth` | Yes | [Go!](https://www.flickr.com/services/api/) |
 | Gfycat | Jiffier GIFs | `oAuth` | Yes | [Go!](https://developers.gfycat.com/api/) |
 | Giphy | Get all your gifs | No | Yes | [Go!](https://github.com/Giphy/GiphyAPI) |
@@ -376,7 +376,7 @@ For information on contributing to this project, please see the [contributing gu
 |---|---|---|---|---|
 | City Bikes | City Bikes around the world | No | No | [Go!](http://api.citybik.es/v2/) |
 | Ergast F1 | F1 data from the beginning of the world championships in 1950 | No | No | [Go!](http://ergast.com/mrd/) |
-| FitBit | FitBit Information | No | Yes | [Go!](https://dev.fitbit.com) |
+| Fitbit | Fitbit Information | `oAuth` | Yes | [Go!](https://dev.fitbit.com/) |
 | Football-Data.org | Football Data | No | No | [Go!](http://api.football-data.org) |
 | JCDecaux Bike | JCDecaux's self-service bicycles | `apiKey` query string | Yes | [Go!](https://developer.jcdecaux.com/) |
 | Cricket Live Scores | live-score | `X-Mashape-Key` as header | Yes | [Go!](https://market.mashape.com/dev132/cricket-live-scores) |


### PR DESCRIPTION
OAuth should be capitalized "OAuth" per [RFC 6749](https://tools.ietf.org/html/rfc6749).