### PR TITLE
Added 'Verse'

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ For information on contributing to this project, please see the [contributing gu
 | StackExchange | Q&A forum for developers | `OAuth` | Yes | [Go!](https://api.stackexchange.com/) |
 | Stormpath | User Authentication | `apiKey` | Yes | [Go!](https://stormpath.com/) |
 | UI Names | Generate random fake names | No | Yes | [Go!](https://github.com/thm/uinames) |
+| Verse | Check what's the latest version of your favorite open-source project | No | Yes | [Go!](https://verse.pawelad.xyz/) |
 
 ### Documents & Productivity
 


### PR DESCRIPTION
I just released [Verse](https://github.com/pawelad/verse) and would love to add it to the list.

It's a RESTful API that checks the latest version of your favourite open source project and simplifies the whole process to one HTTP request.