### PR TITLE
add Lob.com address verification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Please note a passing build status indicates all listed APIs are available since
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
 | languagelayer | Language detection | No | Yes | [Go!](https://languagelayer.com) |
+| Lob.com | US Address Verification | `apiKey` | Yes | [Go!](https://lob.com/) |
 | mailboxlayer | Email address validation | No | Yes | [Go!](https://mailboxlayer.com) |
 | numverify | Phone number validation | No | Yes | [Go!](https://numverify.com) |
 | vatlayer | VAT number validation | No | Yes | [Go!](https://vatlayer.com) |


### PR DESCRIPTION
The US address verification API is provided free of charge to all users. Registration is required to obtain an API key, but this can be done freely. Payment methods are required to send LIVE requests but the address verification API also works in TEST mode which you don't need to provide any payment methods for.

Proof API is free: [Lob.com Address Verification Pricing Page](https://lob.com/verification/address/pricing)
