### PR TITLE
Fix Goodreads typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please note a passing build status indicates all listed APIs are available since
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
 | British National Bibliography | Books | No | No | [Go!](http://bnb.data.bl.uk/) |
-| Good Reads | Books | No | Yes | [Go!](https://www.goodreads.com/api) |
+| Goodreads | Books | No | Yes | [Go!](https://www.goodreads.com/api) |
 | Google Books | Books | `OAuth` | Yes | [Go!](https://developers.google.com/books/) |
 
 ### Business


### PR DESCRIPTION
Goodreads is currently referred to as Good Reads which is an obvious typo looking at [their website](https://goodreads.com) or practically anywhere else on the web.