### PR TITLE
Update entry for Marvel Comics

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Please note a passing build status indicates all listed APIs are available since
 | Giant Bomb | Video Games | No | Yes | [Go!](https://www.giantbomb.com/api/documentation) |
 | Guild Wars 2 | Guild Wars 2 Game Information | `apiKey` | Yes | [Go!](https://wiki.guildwars2.com/wiki/API:Main) |
 | Magic The Gathering | Magic The Gathering Game Information | No | No | [Go!](http://magicthegathering.io/) |
-| Marvel | Marvel Comics | No | No | [Go!](http://developer.marvel.com) |
+| Marvel | Marvel Comics | `apiKey` | No | [Go!](http://developer.marvel.com) |
 | Minecraft | Minecraft server info & user info) | No | Yes | [Go!](https://mcapi.ca/) |
 | Open Trivia | Trivia Questions | No | Yes | [Go!](https://opentdb.com/api_config.php) |
 | Pokéapi | Pokémon Information | No | No | [Go!](http://pokeapi.co) |


### PR DESCRIPTION
Marvel now requires an account to get an api key.

Even playing with the documentation requires the user to have logged in to get actual results.