### PR TITLE
Add The Guardian Open Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Please note a passing build status indicates all listed APIs are available since
 |---|---|---|---|---|
 | New York Times | Provides news | `apikey` | Yes | [Go!](https://developer.nytimes.com/) |
 | News API | headlines currently published on a range of news sources and blogs | `apikey` | Yes | [Go!](https://newsapi.org/) |
+| The Guardian | Access all the content the Guardian creates, categorised by tags and section | `apikey` | Yes | [Go!](http://open-platform.theguardian.com/) |
 
 ### Open Source projects
 


### PR DESCRIPTION
[The Open Platform](http://open-platform.theguardian.com/) is a public web service for accessing all the content the Guardian creates, categorized by tags and section.

The Developer key (for any non-commercial usage of the content, such as student dissertations, hackathons, nonprofit app developers) has the following features:

* Up to 12 calls per second
* Up to 5,000 calls per day
* Access to article text
* Access to over 1,900,000 pieces of content
* Free for non-commercial usage

Even though they do have a commercial version, the free Developer version seems quite helpful and enough for most developer needs.