### PR TITLE
Fix Kitsu API docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Please note a passing build status indicates all listed APIs are available since
 | API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
 | AniList | AniList Anime | `OAuth` | No | [Go!](http://anilist-api.readthedocs.io/en/latest/) |
-| Kitsu | Kitsu Anime | `OAuth` | No | [Go!](http://docs.kitsu17.apiary.io/) |
+| Kitsu | Anime discovery platform | `OAuth` | Yes | [Go!](http://docs.kitsu.apiary.io/) |
 | Studio Ghibli | Resources from Studio Ghibli films | No | Yes | [Go!](https://ghibliapi.herokuapp.com) |
 
 ### Anti-Malware


### PR DESCRIPTION
`kitsu17` was a temporary apiary page - its [now](https://github.com/hummingbird-me/api-docs) just `kitsu`.

Also fixed the `HTTPS` column as it has always been HTTPS-only