### PR TITLE
Fix --allow syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm: 2.2
 before_script: gem install awesome_bot
-script: awesome_bot README.md --allow-ssl --allow 403 302
+script: awesome_bot README.md --allow-ssl --allow 403,302
 notifications:
   email: false


### PR DESCRIPTION
HTTP Codes in the `--allow` option are comma separated.
This should fix the following error in the builds:

```
File open error: No such file or directory @ rb_sysopen - 302

Summary

README.md: ✓

      302: No such file or directory @ rb_sysopen - 302

The command "awesome_bot README.md --allow-ssl --allow 403 302" exited with 1.
```