### PR TITLE
Validate PR updates exclusively

### DIFF
--- a/build/main.sh
+++ b/build/main.sh
@@ -3,6 +3,8 @@ FORMAT_FILE=../README.md
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     echo "running on Pull Request #$TRAVIS_PULL_REQUEST"
     git show | egrep "\+" > additions.txt
+    echo "--ADDITIONS--"
+    cat additions.txt
     LINK_FILE=additions.txt
 else
     echo "running on $TRAVIS_BRANCH branch"

--- a/build/main.sh
+++ b/build/main.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+CHECK_FILE=../README.md
 echo "running format validation..."
-./validate_format.rb ../README.md
+./validate_format.rb $CHECK_FILE
 if [[ $? != 0 ]]; then
     echo "format validation failed!"
     exit 1
@@ -10,7 +11,7 @@ fi
 
 if [ "$TRAVIS_BRANCH" == "master" ]; then
     echo "running link validation..."
-    ./validate_links.rb ../README.md
+    ./validate_links.rb $CHECK_FILE
     if [[ $? != 0 ]]; then
         echo "link validation failed!"
         exit 1

--- a/build/main.sh
+++ b/build/main.sh
@@ -27,6 +27,9 @@ if [ "$TRAVIS_BRANCH" == "master" ]; then
         echo "link validation failed!"
         exit 1
     else
+        if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+            echo "no links to check on $TRAVIS_BRANCH branch - script failure!"
+        fi
         echo "link validation passed!"
     fi
 fi

--- a/build/main.sh
+++ b/build/main.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-CHECK_FILE=../README.md
+FORMAT_FILE=../README.md
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    echo "running on Pull Request #$TRAVIS_PULL_REQUEST"
+    git show | egrep "\+" > additions.txt
+    LINK_FILE=additions.txt
+else
+    echo "running on $TRAVIS_BRANCH branch"
+    LINK_FILE=../README.md
+fi
+
 echo "running format validation..."
-./validate_format.rb $CHECK_FILE
+./validate_format.rb $FORMAT_FILE
 if [[ $? != 0 ]]; then
     echo "format validation failed!"
     exit 1
@@ -11,7 +20,7 @@ fi
 
 if [ "$TRAVIS_BRANCH" == "master" ]; then
     echo "running link validation..."
-    ./validate_links.rb $CHECK_FILE
+    ./validate_links.rb $LINK_FILE
     if [[ $? != 0 ]]; then
         echo "link validation failed!"
         exit 1

--- a/build/validate_links.rb
+++ b/build/validate_links.rb
@@ -17,6 +17,10 @@ raw_links.each do |link|
         links.push(link)
     end
 end
+if links.length <= 0
+    puts "no links to check"
+    exit(0)
+end
 fails = []
 # Fail on any duplicate elements
 dup = links.select{|element| links.count(element) > 1}


### PR DESCRIPTION
This amends the way CI approves a PR. Currently, a PR CI build will fail if any link is invalid when the PR is opened, resulting in many PR failures being false negatives. With the update, CI will only check links modified by the request, not all. This should result in accurate CI failures. If no one has objections, I will be merging this in to master-branch over the weekend.