### PR TITLE
Add Pocket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ API | Description | Auth | HTTPS |Link |
 |---|---|---|---|---|
 | File.io | File Sharing | No | Yes | [Go!](https://www.file.io) |
 | pdflayer API | HTML/URL to PDF | No | Yes | [Go!](https://pdflayer.com) |
+| Pocket | Bookmarking service | `OAuth` | Yes | [Go!](https://getpocket.com/developer/) |
 | PrexView | Data from XML or JSON to PDF, HTML or Image  | `apiKey` | Yes | [Go!](https://prexview.com) |
 | Todoist | Todo Lists | `OAuth` | Yes | [Go!](https://developer.todoist.com) |
 | Wunderlist | Todo Lists | `OAuth` | Yes | [Go!](https://developer.wunderlist.com/documentation) |


### PR DESCRIPTION
This adds [Pocket API](https://getpocket.com/developer/) to the list.