### PR TITLE
Updated APIs list with ADS-B flight data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Please note a passing build status indicates all listed APIs are available since
 * [Anime](#anime)
 * [Anti-Malware](#anti-malware)
 * [Art & Design](#art--design)
-* [Aviation](#aviation)
 * [Books](#books)
 * [Business](#business)
 * [Calendar](#calendar)
@@ -83,11 +82,6 @@ API | Description | Auth | HTTPS | Link |
 | Icons8 | Icons | `OAuth` | Yes | [Go!](http://docs.icons8.apiary.io/#reference/0/meta) |
 | Noun Project | Icons | `OAuth` | No | [Go!](http://api.thenounproject.com/index.html) |
 | Rijksmuseum| Art | `apiKey` | Yes | [Go!](https://www.rijksmuseum.nl/en/api) |
-
-### Aviation
-API | Description | Auth | HTTPS | Link |
-|---|---|---|---|---|
-| ADS-B Exchange | Access real-time and historical data of any and all airbone aircraft. | No | Yes | [Go!](https://www.adsbexchange.com/data/) |
 
 ### Books
 API | Description | Auth | HTTPS | Link |
@@ -459,6 +453,7 @@ API | Description | Auth | HTTPS | Link |
 ### Transportation
 API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
+| ADS-B Exchange | Access real-time and historical data of any and all airbone aircraft. | No | Yes | [Go!](https://www.adsbexchange.com/data/) |
 | Amadeus Travel Innovation Sandbox | Travel Search - Limited usage | `apiKey` | Yes | [Go!](https://sandbox.amadeus.com/) |
 | Bay Area Rapid Transit | Stations and predicted arrivals for BART | `apiKey` | No | [Go!](http://api.bart.gov) |
 | Community Transit | Transitland API | No | Yes | [Go!](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints) |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please note a passing build status indicates all listed APIs are available since
 * [Anime](#anime)
 * [Anti-Malware](#anti-malware)
 * [Art & Design](#art--design)
+* [Aviation](#aviation)
 * [Books](#books)
 * [Business](#business)
 * [Calendar](#calendar)
@@ -82,6 +83,11 @@ API | Description | Auth | HTTPS | Link |
 | Icons8 | Icons | `OAuth` | Yes | [Go!](http://docs.icons8.apiary.io/#reference/0/meta) |
 | Noun Project | Icons | `OAuth` | No | [Go!](http://api.thenounproject.com/index.html) |
 | Rijksmuseum| Art | `apiKey` | Yes | [Go!](https://www.rijksmuseum.nl/en/api) |
+
+### Aviation
+API | Description | Auth | HTTPS | Link |
+|---|---|---|---|---|
+| ADS-B Exchange | Access real-time and historical data of any and all airbone aircraft. | No | Yes | [Go!](https://www.adsbexchange.com/data/) |
 
 ### Books
 API | Description | Auth | HTTPS | Link |


### PR DESCRIPTION
I have added the API provided by the ADS-B Exchange, giving access to both real-time and historical information for flying aircraft. The API is [available at the ADS-B exchange website](https://www.adsbexchange.com/data/), free of charge for non-commercial use.

I did not feel that any available categories aligned with the services offered through this API. 

For the "Vehicles" category, though yes, airplanes are vehicles, this API is not offering a service to learn more about specific vehicles or get more information regarding a certain aircraft model.

For the "Transportation" category, the existing services listed all relate to transportation readily available to passengers, such as those related to personal travel. This API details information for all kinds of aircraft, including military and private training aircraft.