### PR TITLE
added NYPL menus API

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ API | Description | Auth | HTTPS | Link |
 | TacoFancy | Community-driven taco database | No | No | [Go!](https://github.com/evz/tacofancy-api) |
 | TheCocktailDB | Cocktail Recipes | No | No | [Go!](http://www.thecocktaildb.com/) |
 | The Report of the Week | Food & Drink Reviews | No | Yes | [Go!](https://github.com/andyklimczak/TheReportOfTheWeek-API) |
+| What's on the menu? | NYPL human-transcribed historical menu collection | `apiKey` | No | [Go!](nypl.github.io/menus-api/) |
 | Yummly | Find food recipes | No | Yes | [Go!](https://developer.yummly.com/) |
 | Zomato | Discover restaurants | `apiKey` | Yes | [Go!](https://developers.zomato.com/api) |
 


### PR DESCRIPTION
API to the [NYPL historical menu transcription project](http://menus.nypl.org/) data.

API link: http://nypl.github.io/menus-api/
Main project link: http://menus.nypl.org/