### PR TITLE
Adding Federal Register

### DIFF
--- a/json/entries.json
+++ b/json/entries.json
@@ -1570,6 +1570,14 @@
             "Section": "Open Data"
         },
         {
+            "API": "Federal Register",
+            "Auth": null,
+            "Description": "The Daily Journal of the United States Government",
+            "HTTPS": true,
+            "Link": "https://www.federalregister.gov/reader-aids/developer-resources",
+            "Section": "Open Data"
+        },
+        {
             "API": "fonoApi",
             "Auth": null,
             "Description": "Mobile Device Description",


### PR DESCRIPTION
The Federal Register is the daily journal of the US Government. It catalogs rulings, proposed rules, items for public inspection, and notices. 

For an example of what the API provides try this link:
https://www.federalregister.gov/api/v1/documents/2017-10853.json

Thank you for taking the time to work on a Pull Request for this project!

To ensure your PR is dealt with swiftly please check the following:
