### PR TITLE
Add Mercury API

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ API | Description | Auth | HTTPS | Link |
 API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
 | File.io | File Sharing | No | Yes | [Go!](https://www.file.io) |
-| Mercury | Web parser | apiKey | Yes | [Go!](https://mercury.postlight.com/web-parser/) |
+| Mercury | Web parser | `apiKey` | Yes | [Go!](https://mercury.postlight.com/web-parser/) |
 | pdflayer API | HTML/URL to PDF | No | Yes | [Go!](https://pdflayer.com) |
 | Pocket | Bookmarking service | `OAuth` | Yes | [Go!](https://getpocket.com/developer/) |
 | PrexView | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | [Go!](https://prexview.com) |

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ API | Description | Auth | HTTPS | Link |
 API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
 | File.io | File Sharing | No | Yes | [Go!](https://www.file.io) |
+| Mercury | Web parser | apiKey | Yes | [Go!](https://mercury.postlight.com/web-parser/) |
 | pdflayer API | HTML/URL to PDF | No | Yes | [Go!](https://pdflayer.com) |
 | Pocket | Bookmarking service | `OAuth` | Yes | [Go!](https://getpocket.com/developer/) |
 | PrexView | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | [Go!](https://prexview.com) |


### PR DESCRIPTION
Mercury API takes an URL and return the parsed HTML in a JSON format. Eg. headline, author, body text, relevant images and more — free from any clutter. It’s free. Uses apiKey and requires opening an account to get the key.