### PR TITLE
Adding two cryptocurrencies APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,9 @@ API | Description | Auth | HTTPS | Link |
 | Barchart OnDemand | Stock, Futures, and Forex Market Data | `apiKey` | Yes | [Go!](https://www.barchartondemand.com/free) |
 | Blockchain | Bitcoin Payment, Wallet & Transaction Data | No | Yes | [Go!](https://www.blockchain.info/api) |
 | CoinDesk | Bitcoin Price Index | No | No | [Go!](http://www.coindesk.com/api/) |
+| CoinMarketCap | Cryptocurrencies Prices | No | No | [Go!](https://coinmarketcap.com/api/) |
 | Consumer Financial Protection Bureau | Financial services consumer complains data | `apiKey` | Yes | [Go!](https://data.consumerfinance.gov/resource/jhzv-w97w.json) |
+| CryptoCompare | Cryptocurrencies Comparison | No | No | [Go!](https://www.cryptocompare.com/api#) |
 | Czech National Bank | A collection of exchange rates | No | No | [Go!](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) |
 | IEX | Stocks and Market Data | No | Yes | [Go!](https://iextrading.com/developer/) |
 | Razorpay IFSC | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | [Go!](https://ifsc.razorpay.com/) |


### PR DESCRIPTION
[CoinMarketCap](https://coinmarketcap.com/api/) and [CryptoCompare](https://www.cryptocompare.com/api#) both are equally good but CryptoCompare supports logos for each currency which is a nice commodity. Thought this might be a good addition.

