### PR TITLE
Added DigitalOcean Status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ API | Description | Auth | HTTPS | Link |
 | CDNJS | Library info on CDNJS | No | Yes | [Go!](https://api.cdnjs.com/libraries/jquery) |
 | Changelogs.md | Structured changelog metadata from open source projects | No | Yes | [Go!](https://changelogs.md) |
 | Count.io | Persistent counting and A/B testing | No | Yes | [Go!](https://count.io) |
+| DigitalOcean Status | Status of all DigitalOcean services | No | Yes | [Go!](https://status.digitalocean.com/api/v1) |
 | Faceplusplus | A tool to detect face | `OAuth` | Yes | [Go!](https://www.faceplusplus.com/) |
 | Genderize.io | Determines a gender from a first name | No | Yes | [Go!](https://genderize.io) |
 | Github - User Data | Pull public information for a user's github | No | Yes | [Go!](https://api.github.com/users/hackeryou) |


### PR DESCRIPTION
I have added the DigitalOcean Status API to the development category. It is a free JSON API that gets the status of services for free. Not to be confused with the normal DO API.

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md).
- [x] Your changes are made in the [README](../README.md) file, not the auto-generated JSON. 
- [x] Your additions are ordered alphabetically.
- [x] Your submission has a useful description.
- [x] Each table column should be padded with one space on either side.
- [x] You have searched the repository for any relevant issues or PRs.
- [x] Any category you are creating has the minimum requirement of 3 items.
