### PR TITLE
 added Geolocation API for IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ API | Description | Auth | HTTPS | Link |
 | adresse.data.gouv.fr | Address database of France, geocoding, and reverse | No | Yes | [Go!](https://adresse.data.gouv.fr) |
 | Battuta | A (country/region/city) in-cascade location API | `apiKey` | Yes | [Go!](https://battuta.medunes.net) |
 | Bing Maps | Create/customize digital maps based on Bing Maps data | `apiKey` | Yes | [Go!](https://www.microsoft.com/maps/) |
+| FreeGeoIP  | Geolocation of IP addresses | No | Yes | [Go!](https://freegeoip.net/) |
 | GeoApi | French geographical data | No | Yes | [Go!](https://api.gouv.fr/api/geoapi.html) |
 | Geocode.xyz | Provides worldwide forward/reverse geocoding, batch geocoding and geoparsing | No | Yes | [Go!](https://geocode.xyz/) |
 | GeoNames | Place names and other geographical data | No | No | [Go!](http://www.geonames.org/export/web-services.html) |

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ API | Description | Auth | HTTPS | Link |
 | adresse.data.gouv.fr | Address database of France, geocoding, and reverse | No | Yes | [Go!](https://adresse.data.gouv.fr) |
 | Battuta | A (country/region/city) in-cascade location API | `apiKey` | Yes | [Go!](https://battuta.medunes.net) |
 | Bing Maps | Create/customize digital maps based on Bing Maps data | `apiKey` | Yes | [Go!](https://www.microsoft.com/maps/) |
-| FreeGeoIP  | Geolocation of IP addresses | No | Yes | [Go!](https://freegeoip.net/) |
+| FreeGeoIP | Geolocation of IP addresses | No | Yes | [Go!](https://freegeoip.net/) |
 | GeoApi | French geographical data | No | Yes | [Go!](https://api.gouv.fr/api/geoapi.html) |
 | Geocode.xyz | Provides worldwide forward/reverse geocoding, batch geocoding and geoparsing | No | Yes | [Go!](https://geocode.xyz/) |
 | GeoNames | Place names and other geographical data | No | No | [Go!](http://www.geonames.org/export/web-services.html) |


### PR DESCRIPTION
Greetings!

freegeoip.net provides a public HTTP API for software developers to search the geolocation of IP addresses. It uses a database of IP addresses that are associated to cities along with other relevant information like time zone, latitude and longitude.

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md).
- [x] Your changes are made in the [README](../README.md) file, not the auto-generated JSON. 
- [x] Your additions are ordered alphabetically.
- [x] Your submission has a useful description.
- [x] Each table column should be padded with one space on either side.
- [x] You have searched the repository for any relevant issues or PRs.
- [ ] Any category you are creating has the minimum requirement of 3 items.
