### PR TITLE
Add note about PR label in template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,7 @@ To ensure your PR is dealt with swiftly please check the following:
 - [ ] Each table column should be padded with one space on either side.
 - [ ] You have searched the repository for any relevant issues or PRs.
 - [ ] Any category you are creating has the minimum requirement of 3 items.
+
+During the discussion, you may be asked to make some changes to your pull request. 
+
+If so, the reviewer will add a *Contributor input required* label to the Pull Request. After you make the requested changes, please remove the label so the reviewer knows that you are ready for another review. 


### PR DESCRIPTION
We have these very nice labels for a PR's status (thanks @mikestreety) but 9 times out of 10 the *Contributor Input Required* label stays on even after the user makes the requested changes....

Hopefully adding a note to the PR template will help people remember to remove the "the ball is in my court" label.

Opening a PR in case you guys think something else should also be included in the template.

