### PR TITLE
Added Food Standards Agency to Government table

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ API | Description | Auth | HTTPS | Link |
 | Census.gov | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | [Go!](https://www.census.gov/data/developers/data-sets.html) |
 | EPA | Web services and data sets from the US Environmental Protection Agency | No | Yes | [Go!](https://developer.epa.gov/category/api/) |
 | FEC | Information on campaign donations in federal elections | `apiKey` | Yes | [Go!](https://api.open.fec.gov/developers/) |
+| Food Standards Agency | UK food hygiene rating data API. The data provides the food hygiene rating or inspection result given to a business and reflects the standards of food hygiene found on the date of inspection or visit by the local authority. | No | No | [Go!](http://ratings.food.gov.uk/open-data/en-GB) |
 | Regulations.gov | Regulations.gov provides access to Federal regulatory materials and increases public participation and their understanding of the Federal rule making process | `apiKey` | Yes | [Go!](https://regulationsgov.github.io/developers/) |
 
 ### Health

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ API | Description | Auth | HTTPS | Link |
 | Census.gov | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | [Go!](https://www.census.gov/data/developers/data-sets.html) |
 | EPA | Web services and data sets from the US Environmental Protection Agency | No | Yes | [Go!](https://developer.epa.gov/category/api/) |
 | FEC | Information on campaign donations in federal elections | `apiKey` | Yes | [Go!](https://api.open.fec.gov/developers/) |
-| Food Standards Agency | UK food hygiene rating data API. The data provides the food hygiene rating or inspection result given to a business and reflects the standards of food hygiene found on the date of inspection or visit by the local authority | No | No | [Go!](http://ratings.food.gov.uk/open-data/en-GB) |
+| Food Standards Agency | UK food hygiene rating data API | No | No | [Go!](http://ratings.food.gov.uk/open-data/en-GB) |
 | Regulations.gov | Regulations.gov provides access to Federal regulatory materials and increases public participation and their understanding of the Federal rule making process | `apiKey` | Yes | [Go!](https://regulationsgov.github.io/developers/) |
 
 ### Health

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ API | Description | Auth | HTTPS | Link |
 | Census.gov | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | [Go!](https://www.census.gov/data/developers/data-sets.html) |
 | EPA | Web services and data sets from the US Environmental Protection Agency | No | Yes | [Go!](https://developer.epa.gov/category/api/) |
 | FEC | Information on campaign donations in federal elections | `apiKey` | Yes | [Go!](https://api.open.fec.gov/developers/) |
-| Food Standards Agency | UK food hygiene rating data API. The data provides the food hygiene rating or inspection result given to a business and reflects the standards of food hygiene found on the date of inspection or visit by the local authority. | No | No | [Go!](http://ratings.food.gov.uk/open-data/en-GB) |
+| Food Standards Agency | UK food hygiene rating data API. The data provides the food hygiene rating or inspection result given to a business and reflects the standards of food hygiene found on the date of inspection or visit by the local authority | No | No | [Go!](http://ratings.food.gov.uk/open-data/en-GB) |
 | Regulations.gov | Regulations.gov provides access to Federal regulatory materials and increases public participation and their understanding of the Federal rule making process | `apiKey` | Yes | [Go!](https://regulationsgov.github.io/developers/) |
 
 ### Health


### PR DESCRIPTION
I've added an entry for the "Food Standards Agency", a UK food hygiene rating data API.

I hope "Government" is the right place to put this, as this is a UK government website. However I guess it could also be housed under "Food &Drink"?

Thank you for taking the time to work on a Pull Request for this project!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md).
- [x] Your changes are made in the [README](../README.md) file, not the auto-generated JSON. 
- [x] Your additions are ordered alphabetically.
- [x] Your submission has a useful description.
- [x] Each table column should be padded with one space on either side.
- [x] You have searched the repository for any relevant issues or PRs.
- [x] Any category you are creating has the minimum requirement of 3 items.
