### PR TITLE
bug: Deleted nomad list api. It's close since 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,6 @@ API | Description | Auth | HTTPS | Link |
 | Indian Railways | Indian Railways Information | `apiKey` | No | [Go!](http://api.erail.in/) |
 | Izi | Audio guide for travellers | `apiKey` | Yes | [Go!](http://api-docs.izi.travel/) |
 | Navitia | The open API for building cool stuff with transport data | `apiKey` | Yes | [Go!](https://api.navitia.io/) |
-| Nomad List | A list of the best places to live/work remotely | No | Yes | [Go!](https://nomadlist.com/faq) |
 | REFUGE Restrooms | Provides safe restroom access for transgender, intersex, and gender nonconforming individuals | No | Yes | [Go!](https://www.refugerestrooms.org/api/docs/#!/restrooms) |
 | Schiphol Airport | Schiphol | `apiKey` | Yes | [Go!](https://developer.schiphol.nl/) |
 | TransitLand | Transit Aggregation | No | Yes | [Go!](https://transit.land/documentation/datastore/api-endpoints.html) |


### PR DESCRIPTION
Hi everybody. Today i tried to use Nomad List API and after a while looking for it I have seen the official news that they have deactivated it.

https://nomadlist.com/help


![img of oficial web](https://image.prntscr.com/image/o7IssOQUSV2VSlTX7JUakQ.png)