### PR TITLE
Add Public API for Public APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A collective list of free APIs for use in web development.
 
-A JSON encoding of all entries can be found [here](json).
+A public API for this project can be found [here](https://github.com/davemachado/public-api).
 
 For information on contributing to this project, please see the [contributing guide](.github/CONTRIBUTING.md).
 
@@ -212,7 +212,7 @@ API | Description | Auth | HTTPS | CORS | Link |
 | LiveEdu | Live Coding Streaming | `OAuth` | Yes | Unknown | [Go!](https://www.liveedu.tv/developer/applications/) |
 | Myjson | A simple JSON store for your web or mobile app | No | No | Unknown | [Go!](http://myjson.com/api) |
 | Plino | Spam filtering system | No | Yes | Unknown | [Go!](https://plino.herokuapp.com/) |
-| Public APIs | A collective list of free JSON APIs for use in web development | No | Yes | Unknown | [Go!](https://github.com/toddmotto/public-apis/tree/master/json) |
+| Public APIs | A collective list of free JSON APIs for use in web development | No | Yes | Unknown | [Go!](https://github.com/davemachado/public-api) |
 | QR code | Generate and decode / read QR code graphics | No | Yes | Unknown | [Go!](http://goqr.me/api/) |
 | ReqRes | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown | [Go!](https://reqres.in/ ) |
 | Scrape Website Email | Grabs email addresses from a URL | `X-Mashape-Key` | Yes | Unknown | [Go!](https://market.mashape.com/tommytcchan/scrape-website-email) |


### PR DESCRIPTION
Alright, I am back again with a finished (very-early-stage) API!

Thanks to some help from DigitalOcean, I was able to build and deploy a [free service](https://github.com/davemachado/public-api) to interact with the data in this project. Currently, the only solid endpoint allows a user to filter down all (now 500) of the entries in the list by category, HTTPS support, Auth type, etc. However, I will be adding more to this in the near future (so many branches, so little time...)

Speaking of, congrats to everyone for getting this project to such a large collection! It has been an honor and a privilege to help and watch this grow to such a "force to reference with" in the Open Source community!  🎉   🎊   
