### PR TITLE
Define TimeoutError in Python 2

### DIFF
--- a/build/validate_links.py
+++ b/build/validate_links.py
@@ -5,6 +5,11 @@ import re
 import socket
 import sys
 
+try:
+    TimeoutError            # Python 3
+except NameError:
+    TimeoutError = OSError  # Python 2
+
 
 def parse_links(filename):
     """Returns a list of URLs from text file"""


### PR DESCRIPTION
The README and contributing guide say nothing about Python 2 vs. 3 but .travis.yml is only testing on Python 3.

https://docs.python.org/3/library/exceptions.html#TimeoutError was defined in Python 3.3

Feel free to close this PR if the project only wants to support Python 3.

Is is an imperfect PR in any case because not all OSError are TimeoutErrors.

Thank you for taking the time to work on a Pull Request for this project!

To ensure your PR is dealt with swiftly please check the following:

- [ ] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [ ] Your changes are made in the [README](../README.md) file, not the auto-generated JSON 
- [ ] Your additions are ordered alphabetically
- [ ] Your submission has a useful description
- [ ] The description does not end with punctuation
- [ ] Each table column should be padded with one space on either side
- [ ] You have searched the repository for any relevant issues or pull requests
- [ ] Any category you are creating has the minimum requirement of 3 items
