### PR TITLE
Add HERE Maps API

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ API | Description | Auth | HTTPS | CORS | Link |
 | Google Maps | Create/customize digital maps based on Google Maps data | `apiKey` | Yes | Unknown | [Go!](https://developers.google.com/maps/) |
 | GraphLoc | Free GraphQL IP Geolocation API | No | Yes | Unknown | [Go!](https://www.graphloc.com) |
 | HelloSalut | Get hello translation following user language | No | Yes | Unknown | [Go!](https://www.fourtonfish.com/hellosalut/hello/) |
+| HERE Maps | Create/customize digital maps based on HERE Maps data | `apiKey` | Yes | Unknown | [Go!](https://developer.here.com) |
 | IP 2 Country | Map an IP to a country | No | Yes | Unknown | [Go!](https://ip2country.info) |
 | IP Address Details | Find geolocation with ip address | No | Yes | Unknown | [Go!](https://ipinfo.io/) |
 | IP Location | Find IP address location information | No | Yes | Unknown | [Go!](https://ipapi.co/) |


### PR DESCRIPTION
I thought worth adding the HERE Maps API, since:

 - there is a free plan which is not limited in time
 - the free plan includes quite some features (map tiles, geocoding, places, routing, etc.)

Source: https://developer.here.com/plans (choose "For the Public")

## Checklist

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- [x] Any category you are creating has the minimum requirement of 3 items
