### PR TITLE
Czech personal identification numbers validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ API | Description | Auth | HTTPS | CORS | Link |
 | MailTest | Email address validation | No | Yes | Unknown | [Go!](http://mailtest.in/documentation/) |
 | NumValidate | Open Source phone number validation | No | Yes | Unknown | [Go!](https://numvalidate.com) |
 | numverify | Phone number validation | No | Yes | Unknown | [Go!](https://numverify.com) |
+| Personal identification number validation | Validates PIN and generates valid PINs| No | Yes | Yes | [Go!](https://rcapi.abalin.net) |
 | PurgoMalum | Content validator against profanity & obscenity | No | No | Unknown | [Go!](http://www.purgomalum.com) |
 | vatlayer | VAT number validation | No | Yes | Unknown | [Go!](https://vatlayer.com) |
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ API | Description | Auth | HTTPS | CORS | Link |
 | MailTest | Email address validation | No | Yes | Unknown | [Go!](http://mailtest.in/documentation/) |
 | NumValidate | Open Source phone number validation | No | Yes | Unknown | [Go!](https://numvalidate.com) |
 | numverify | Phone number validation | No | Yes | Unknown | [Go!](https://numverify.com) |
-| Personal identification number validation | Validates PIN and generates valid PINs| No | Yes | Yes | [Go!](https://rcapi.abalin.net) |
+| Personal identification number validation | Validates PIN and generates valid PINs. Applies to CZ and SK numbers only| No | Yes | Yes | [Go!](https://rcapi.abalin.net) |
 | PurgoMalum | Content validator against profanity & obscenity | No | No | Unknown | [Go!](http://www.purgomalum.com) |
 | vatlayer | VAT number validation | No | Yes | Unknown | [Go!](https://vatlayer.com) |
 


### PR DESCRIPTION
Adding new API for validation Czech personal identification numbers (rodna cisla) an equivalent of Social security number in US. Applies to Czech and Slovak numbers only.