### PR TITLE
Updated Transport for Boston, US

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Transport for Auckland, New Zealand](https://api.at.govt.nz/) | Auckland Transport | No | Yes | Unknown |
 | [Transport for Belgium](https://hello.irail.be/api/) | Belgian transport API | No | Yes | Unknown |
 | [Transport for Berlin, Germany](https://github.com/derhuerst/vbb-rest/blob/master/docs/index.md) | Third-party VBB API | No | Yes | Unknown |
-| [Transport for Boston, US](http://realtime.mbta.com/Portal/Home/Documents) | MBTA API | No | No | Unknown |
+| [Transport for Boston, US](https://mbta.com/developers/v3-api) | MBTA API | No | No | Unknown |
 | [Transport for Budapest, Hungary](https://apiary.io/) | Budapest public transport API | No | Yes | Unknown |
 | [Transport for Chicago, US](http://www.transitchicago.com/developers/) | CTA | No | No | Unknown |
 | [Transport for Czech Republic](https://www.chaps.cz/eng/products/idos-internet) | Czech transport API | No | Yes | Unknown |


### PR DESCRIPTION
Updated Transport for Boston, US with a working URL.
This will resolve issue #792 