### PR TITLE
Rick and Morty API does not support CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Pokéapi](https://pokeapi.co) | Pokémon Information | No | Yes | Unknown |
 | [Pokémon TCG](https://pokemontcg.io) | Pokémon TCG Information | No | Yes | Unknown |
 | [Qriusity](https://qriusity.com/) | Quiz/Trivia Questions | No | Yes | Unknown |
-| [Rick and Morty](https://rickandmortyapi.com) | All the Rick and Morty information, including images | No | Yes | Yes |
+| [Rick and Morty](https://rickandmortyapi.com) | All the Rick and Morty information, including images | No | Yes | No |
 | [Riot Games](https://developer.riotgames.com/) | League of Legends Game Information | `apiKey` | Yes | Unknown |
 | [Steam](https://developer.valvesoftware.com/wiki/Steam_Web_API) | Steam Client Interaction | `OAuth` | Yes | Unknown |
 | [Vainglory](https://developer.vainglorygame.com/) | Vainglory Players, Matches and Telemetry | `apiKey` | Yes | Yes |


### PR DESCRIPTION
The Rick and Morty API is listed as supporting CORS but it does not.

![image](https://user-images.githubusercontent.com/871117/47885248-476d4380-ddf1-11e8-90bc-b94f2871b2ba.png)

- [ x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [ x] Your additions are ordered alphabetically
- [ x] Your submission has a useful description
- [ x] The description does not end with punctuation
- [ x] Each table column should be padded with one space on either side
- [ x] You have searched the repository for any relevant issues or pull requests
- [ x] Any category you are creating has the minimum requirement of 3 items
- [ x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
