### PR TITLE
IPGeolocationAPI.com a free geolocation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IP Location](https://ipapi.co/) | Find IP address location information | No | Yes | Unknown |
 | [IP Sidekick](https://ipsidekick.com) | Geolocation API that returns extra information about an IP address | `apiKey` | Yes | Unknown |
 | [IP Vigilante](https://www.ipvigilante.com/) | Free IP Geolocation API | No | Yes | Unknown |
+| [IPGeolocationAPI.com](https://ipgeolocationapi.com/) | Locate your visitors by IP with country details | No | Yes | Yes |
 | [ipstack](https://ipstack.com/) | Locate and identify website visitors by IP address | `apiKey` | Yes | Unknown |
 | [LocationIQ](https://locationiq.org/docs/) | Provides forward/reverse geocoding and batch geocoding | `apiKey` | Yes | Yes |
 | [Mapbox](https://www.mapbox.com/developers/) | Create/customize beautiful digital maps | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
IPGeolocationAPI.com provides a JSON API for geolocating website visitors or geolocating IPv4/IPv6 addresses. The returned JSON response contains detailed information about the geolocated country details like ISO 3166 (countries and states/subdivisions ), ISO 4217 (currency), and E.164 (phone numbers).

The service also has a self-configuring "Deploy to Heroku" button so the API can be self-hosted by anyone.

The service has been tested to handle thousands of asynchronous requests and coded in Python. Fully open source and MIT licensed. [Github](https://github.com/madisvain/geolocationapi)

The service with documentation is available at: [IP Geolocation API](https://ipgeolocationapi.com/)

Thank you for taking the time to work on a Pull Request for this project!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- [x] Any category you are creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
