### PR TITLE
Add Openwhyd to public "Music" APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2) | Music | No | Yes | Unknown |
 | [Musikki](https://music-api.musikki.com/reference) | Music | `apiKey` | Yes | Unknown |
 | [Musixmatch](https://developer.musixmatch.com/) | Music | `apiKey` | Yes | Unknown |
+| [Openwhyd](https://github.com/openwhyd/openwhyd/blob/master/docs/API.md) | Allow users to create playlists of streaming tracks (YouTube, SoundCloud, etc...) | `Cookie` | Yes | No |
 | [Songkick](https://www.songkick.com/developer/) | Music Events | `OAuth` | Yes | Unknown |
 | [Songsterr](https://www.songsterr.com/a/wa/api/) | Provides guitar, bass and drums tabs and chords | No | Yes | Unknown |
 | [SoundCloud](https://developers.soundcloud.com/) | Allow users to upload and share sounds | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Hi!

I would like to suggest adding Openwhyd's API to the list of Music APIs.

Openwhyd is a free and open-source music curation service that allows users to create playlists of music tracks from various streaming platforms (YouTube, SoundCloud, Vimeo, Deezer...) and to discover the music from other users.

It's currently used by our main app openwhyd.org and our iPhone app. It could be used as a free back-end for new music apps. (see https://medium.com/openwhyd/dont-build-a-back-end-for-your-android-music-app-7fe93fb43bad)

I did not know how to explain that in the table:
- we also have a public read-only JSON API that does not require authentication: it is documented [here](https://github.com/openwhyd/openwhyd/blob/master/docs/FAQ.md#how-to-export-my-tracks--comment-exporter-ma-musique-en-csv-ou-json-) and used in [this example](https://github.com/adrienjoly/openwhyd-pl-dl)
- I had written a client in Node.js that takes care of generating the session cookie and send requests to Openwhyd's API, given a username and password: https://github.com/adrienjoly/npm-whyd
- Also, our API is used by a 3rd-party web client made with Meteor.js: [Sound-nuggets](https://github.com/SkinyMonkey/sound-nuggets)

I'm happy to help if you have any questions and/or suggested changes.

Thank you for your work, and for your consideration!

---

PR check-list:

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- ~~[ ] Any category you are creating has the minimum requirement of 3 items~~ (N/A)
- [x] All changes have been [squashed][squash-link] into a single commit
