### PR TITLE
Add Openwhyd's public API to the "Music" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2) | Music | No | Yes | Unknown |
 | [Musikki](https://music-api.musikki.com/reference) | Music | `apiKey` | Yes | Unknown |
 | [Musixmatch](https://developer.musixmatch.com/) | Music | `apiKey` | Yes | Unknown |
+| [Openwhyd](https://openwhyd.github.io/openwhyd/API) | Download curated playlists of streaming tracks (YouTube, SoundCloud, etc...) | `No` | Yes | No |
 | [Songkick](https://www.songkick.com/developer/) | Music Events | `OAuth` | Yes | Unknown |
 | [Songsterr](https://www.songsterr.com/a/wa/api/) | Provides guitar, bass and drums tabs and chords | No | Yes | Unknown |
 | [SoundCloud](https://developers.soundcloud.com/) | Allow users to upload and share sounds | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Hi again! This PR is an alternative to #832.

Openwhyd is a free and open-source music curation service that allows users to create playlists of music tracks from various streaming platforms (YouTube, SoundCloud, Vimeo, Deezer...) and to discover the music from other users.

Besides our Cookie-based API (as described in PR #832), we give free access to our users' public profiles and playlists in JSON format.

As an example of use of that API, I wrote a script to download the music tracks mentioned in the JSON response of my own playlists: [openwhyd-pl-dl](https://github.com/adrienjoly/openwhyd-pl-dl)

I'm happy to help if you have any questions and/or suggested changes.

Thanks again for your work, and for your consideration! ^^

---

PR check-list:

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- ~~[ ] Any category you are creating has the minimum requirement of 3 items~~ (N/A)
- [x] All changes have been [squashed][squash-link] into a single commit
