### PR TITLE
Remove street layer because it's going to get discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ API | Description | Auth | HTTPS | CORS |
 | [NumValidate](https://numvalidate.com) | Open Source phone number validation | No | Yes | Unknown |
 | [numverify](https://numverify.com) | Phone number validation | No | Yes | Unknown |
 | [PurgoMalum](http://www.purgomalum.com) | Content validator against profanity & obscenity | No | No | Unknown |
-| [streetlayer](https://streetlayer.com) | Street address info and validation | `apiKey` | Yes | Unknown |
 | [vatlayer](https://vatlayer.com) | VAT number validation | No | Yes | Unknown |
 
 ### Development


### PR DESCRIPTION
Street Layer API will get discontinued soon: 

![remove](https://user-images.githubusercontent.com/15314237/52530980-f9ab8580-2cd3-11e9-80da-69ef2fc37bd4.png)

So might as well remove it. 