### PR TITLE
Remove Ultimate Courses ad

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 A collective list of free APIs for use in software and web development.
 
-Sponsor:
-
-<a href="https://ultimatecourses.com?utm_source=github.com"><img src="https://ultimatecourses.com/assets/img/banners/ultimate-angular-github.svg" style="width:100%;max-width:100%"></a>
-
 A public API for this project can be found [here](https://github.com/davemachado/public-api) - thanks to [DigitalOcean](https://www.digitalocean.com/) for helping us provide this service!
 
 For information on contributing to this project, please see the [contributing guide](.github/CONTRIBUTING.md).


### PR DESCRIPTION
Remove Ultimate Courses ad. We can keep it if it does something for the project or contributors, but it just seems to be taking up space. 

Relevant issue:  #915
